### PR TITLE
Issue 10 done docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  mysql:
+    build:
+      context: ./mysql
+      dockerfile: Dockerfile
+    container_name: simple-crud-mysql
+    restart: unless-stopped
+    ports:
+      - "3307:3306"  # Map to port 3307 to avoid conflict with local MySQL
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: simple_crud_db
+      MYSQL_USER: simple_crud
+      MYSQL_PASSWORD: password
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./mysql/init:/docker-entrypoint-initdb.d
+    networks:
+      - simple-crud-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      timeout: 20s
+      retries: 10
+
+  # Optional: phpMyAdmin for database management
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: simple-crud-phpmyadmin
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    environment:
+      PMA_HOST: mysql
+      PMA_PORT: 3306
+      PMA_USER: root
+      PMA_PASSWORD: password
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - simple-crud-network
+
+volumes:
+  mysql_data:
+    driver: local
+
+networks:
+  simple-crud-network:
+    driver: bridge

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,17 @@
+# MySQL 8.0 Dockerfile for development
+FROM mysql:8.0
+
+# Set environment variables
+ENV MYSQL_ROOT_PASSWORD=password
+ENV MYSQL_DATABASE=simple_crud_db
+ENV MYSQL_USER=simple_crud
+ENV MYSQL_PASSWORD=password
+
+# Copy initialization scripts
+COPY ./init/ /docker-entrypoint-initdb.d/
+
+# Expose MySQL port
+EXPOSE 3306
+
+# Set default command
+CMD ["mysqld"]

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,51 @@
+
+# MySQL Docker Setup
+
+## Overview
+This directory contains Docker configuration for MySQL database used in the Simple CRUD application.
+
+## Files
+- `Dockerfile` - MySQL 8.0 Docker image configuration
+- `init/01-init.sql` - Database initialization script
+- `../docker-compose.yml` - Docker Compose configuration
+
+## Usage
+
+### Start MySQL with Docker
+```bash
+# Start MySQL container
+docker-compose up -d mysql
+
+# View logs
+docker-compose logs mysql
+
+# Stop MySQL container
+docker-compose down
+```
+
+### Connect to MySQL
+```bash
+# Connect using MySQL client
+mysql -h localhost -P 3307 -u root -p
+
+# Or connect using Docker
+docker exec -it simple-crud-mysql mysql -u root -p
+```
+
+### Environment Variables for Docker
+Create `.env` file with:
+```env
+DATABASE_URL="mysql://root:password@localhost:3307/simple_crud_db"
+```
+
+### phpMyAdmin (Optional)
+Access phpMyAdmin at: http://localhost:8080
+- Username: root
+- Password: password
+
+## Ports
+- MySQL: 3307 (mapped from container port 3306)
+- phpMyAdmin: 8080
+
+## Data Persistence
+Database data is persisted in Docker volume `mysql_data`.

--- a/mysql/init/01-init.sql
+++ b/mysql/init/01-init.sql
@@ -1,0 +1,28 @@
+-- Initialize database for Simple CRUD application
+-- This script runs when the MySQL container starts for the first time
+
+-- Create database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS simple_crud_db;
+USE simple_crud_db;
+
+-- Create users table (matching Prisma schema)
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Insert sample data
+INSERT INTO users (name, email) VALUES 
+('John Doe', 'john.doe@example.com'),
+('Jane Smith', 'jane.smith@example.com')
+ON DUPLICATE KEY UPDATE name=VALUES(name);
+
+-- Create indexes for better performance
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_created_at ON users(created_at);
+
+-- Show created tables
+SHOW TABLES;


### PR DESCRIPTION
✅ 完了した作業内容
1. フォルダ構造の作成
mysql/フォルダを作成
mysql/init/フォルダを作成（初期化スクリプト用）
2. Dockerfileの作成
MySQL 8.0ベースのDockerfile
環境変数設定（MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD）
初期化スクリプトのコピー設定
ポート3306の公開
3. 初期化SQLスクリプトの作成
mysql/init/01-init.sqlファイル
simple_crud_dbデータベースの作成
usersテーブルの作成（Prismaスキーマと整合性確保）
サンプルデータの挿入（John Doe, Jane Smith）
パフォーマンス用インデックスの作成
4. docker-compose.ymlの設定
MySQLサービスの設定
ポート3307でマッピング（ローカルMySQLとの競合回避）
ボリューム設定（データ永続化）
ネットワーク設定
ヘルスチェック設定
phpMyAdminの追加設定（ポート8080）
5. ドキュメントの作成
mysql/README.mdでDocker環境の使用方法を説明
接続方法、ポート情報、環境変数の設定例を記載
6. Docker環境のテスト
Dockerデーモンの起動
docker-compose up -d mysqlでコンテナ起動
データベース接続テスト
テーブルとサンプルデータの確認