### PR TITLE
fix: resolve TypeScript errors in backend

### DIFF
--- a/backend/src/controllers/healthController.ts
+++ b/backend/src/controllers/healthController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express';
-import { HealthResponse } from '../types/api.js';
+import type { components } from '../types/api.js';
+
+type HealthResponse = components['schemas']['HealthResponse'];
 
 export const healthCheck = (req: Request, res: Response): void => {
   const healthResponse: HealthResponse = {

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,12 +1,12 @@
 import { Request, Response } from 'express';
-import { 
-  UserResponse, 
-  UsersResponse, 
-  CreateUserRequest, 
-  UpdateUserRequest,
-  PaginationInfo,
-  ErrorResponse
-} from '../types/api.js';
+import type { components } from '../types/api.js';
+
+type UserResponse = components['schemas']['UserResponse'];
+type UsersResponse = components['schemas']['UsersResponse'];
+type CreateUserRequest = components['schemas']['CreateUserRequest'];
+type UpdateUserRequest = components['schemas']['UpdateUserRequest'];
+type PaginationInfo = components['schemas']['PaginationInfo'];
+type ErrorResponse = components['schemas']['ErrorResponse'];
 import { prisma } from '../lib/prisma.js';
 import { CreateUserInput, UpdateUserInput, GetUserParams, GetUsersQuery } from '../schemas/userSchemas.js';
 

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import { ErrorResponse } from '../types/api.js';
+import type { components } from '../types/api.js';
+
+type ErrorResponse = components['schemas']['ErrorResponse'];
 
 export interface AppError extends Error {
   statusCode?: number;

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { z, ZodSchema } from 'zod';
-import { ErrorResponse } from '../types/api.js';
+import type { components } from '../types/api.js';
+
+type ErrorResponse = components['schemas']['ErrorResponse'];
 
 export const validateRequest = (schema: {
   body?: ZodSchema;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -26,6 +26,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/generated/**/*"
   ]
 }


### PR DESCRIPTION
- Fix type imports in controllers and middleware
- Exclude Prisma generated files from TypeScript compilation
- Use proper type aliases for OpenAPI generated types